### PR TITLE
Fix rounding error when calculating element width

### DIFF
--- a/src/lib/ngx-hm-carousel.component.ts
+++ b/src/lib/ngx-hm-carousel.component.ts
@@ -277,7 +277,7 @@ export class NgxHmCarouselComponent implements ControlValueAccessor, AfterViewIn
   private hasInitWriteValue = false;
 
   private get rootElmWidth() {
-    return (isPlatformBrowser(this.platformId) ? this.rootElm.clientWidth : 100);
+    return (isPlatformBrowser(this.platformId) ? this.rootElm.getBoundingClientRect().width : 100);
   }
 
   private set containerElmWidth(value) {


### PR DESCRIPTION
When width of rootElm is not an integer, the decimal part is being lost in the width calculation. Rounding of width may cause to display the carousel improperly (showing 1px of next image).
According to the Mozilla developer docs https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth , proper solution to get exact width is usage of getBoundingClientRect().
Can be used safely in modern browsers: https://caniuse.com/#feat=getboundingclientrect
